### PR TITLE
changed -lEGL -lGLESv2 to -lbrcmEGL -lbrcmGLESv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 BIN=vctest sgles1 svg1 svg2 svg3 svg4
-OBJS=segl.o 
+OBJS=segl.o
 
 CFLAGS+=-I/opt/vc/include/ -I/opt/vc/include/interface/vcos/pthreads/ \
 -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/include/interface/vmcs_host/linux \
 -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM
-LDFLAGS+=segl.o -L/opt/vc/lib/ -lGLESv2 -lEGL -lbcm_host -lvcos -lvchiq_arm -lm
+LDFLAGS+=segl.o -L/opt/vc/lib/ -lbrcmEGL -lbrcmGLESv2 -lbcm_host -lvcos -lvchiq_arm -lm
 
 all: $(OBJS) $(BIN)
 


### PR DESCRIPTION
Apparently they changed the names of these libraries in Raspbian.